### PR TITLE
Fix component for home-assistant >= 2021.3.0

### DIFF
--- a/custom_components/dwd_pollen/manifest.json
+++ b/custom_components/dwd_pollen/manifest.json
@@ -5,5 +5,6 @@
   "dependencies": ["sensor"],
   "after_dependencies": ["rest"],
   "codeowners": [],
-  "requirements": ["voluptuous==0.12.1", "jsonpath==0.82"]
+  "requirements": ["voluptuous==0.12.1", "jsonpath==0.82"],
+  "version": "0.1.0"
 }

--- a/custom_components/dwd_pollen/sensor.py
+++ b/custom_components/dwd_pollen/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_NAME)
 from homeassistant.util import Throttle
-from homeassistant.components.rest.sensor import RestData
+from homeassistant.components.rest.data import RestData
 
 STAT_AVG = 'avg'
 


### PR DESCRIPTION
`RestData` has been moved to `data.py` some time ago, so let's import it from there. Also, add a version key to `manifest.json`, as this will be required in future versions.

Closes marcschumacher/dwd_pollen#4